### PR TITLE
Collision Message Proposal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ find_package(std_msgs REQUIRED)
 
 set(msg_files
     "msg/Bounds.msg"
+    "msg/Collision.msg"
+    "msg/Collisions.msg"
     "msg/EntityCategory.msg"
     "msg/EntityFilters.msg"
     "msg/EntityInfo.msg"

--- a/msg/Collision.msg
+++ b/msg/Collision.msg
@@ -1,0 +1,5 @@
+geometry_msgs/Point location  # Using Collisions.header
+
+# Unique names for the two entities in collision
+string entity0
+string entity1

--- a/msg/Collisions.msg
+++ b/msg/Collisions.msg
@@ -1,0 +1,4 @@
+# The header contains the timestamp for the detection
+# and the frame that each collision's location is reported in
+std_msgs/Header header
+simulation_interfaces/Collision[] collisions


### PR DESCRIPTION
I have wanted a collision reporting scheme that could work across multiple simulators.

We have [`gazebo_ros_pkgs/ContactState.msg`](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/5e718169353e2c21f85e15fd4b743011b3ad9b57/gazebo_msgs/msg/ContactState.msg) (and `ContactsState`) which contained
 * the generic string `info`
 * Two names
 * `geometry_msgs/Wrench[]` for enumerating forces/torques
 * One `Wrench` for the total force/torque
 * `Vector3[]` contact positions
 * `Vector3[]` contact normals (presumably the same size as positions)
 * `float64[] depths` - Penetration depths

I boiled it down to a non-simulation specific pair of messages in [collision_log_msgs/NamedCollision.msg](https://github.com/MetroRobots/metrics_msgs/blob/main/collision_log_msgs/msg/NamedCollision.msg) which stripped it down to the two names. 

There is also [moveit_msgs/ContactInformation.msg](https://github.com/moveit/moveit_msgs/blob/master/msg/ContactInformation.msg) which has
 * `Point` position
 * `Vector3` normal
 * `float64 depth`
 * Two names, and associated body types (robot link/world object/robot attached)

## Example
Consider [this scenario:](https://docs.google.com/drawings/d/1X05BQI1H-DuVgc5kCixtNGkdNI0cyiS6-nFBQohKGaQ/edit?usp=sharing)

![Collision Message](https://github.com/user-attachments/assets/6d522db8-c4b2-42f4-8070-e8a3314afa4e)

We have four entities. At the time depicted, it might show 
```
header:
    frame_id: /world
    stamp: 1234
collisions:
 - location: -3, 0, 0
   entity0: ground
   entity1: shaky
 - location: -2, 0, 0
   entity0: ground
   entity1: shaky
 - location: 1, 0, 0
   entity0: ground
   entity1: table
 - location: 1.5, 0, 1
   entity0: table
   entity1: arm
 - location: -2.5, 0, 1.5
   entity0: arm
   entity1: shaky
```

## Considerations
 * Even if the table is a box, there's likely many/infinite contact points between it and the ground. How should that be represented? 
 * The spec allows for `entity0 == entity1`, i.e. detect if the arm was in self collision
 * Do we want additional fields for specifying more information about the subcomponent that is colliding? i.e. Do we want to know that /shaky/left_wheel is the in collision? Does that require additional contact positions (in the frame /left_wheel perhaps?)
 * How much optional physics info do we need? i.e. normals/forces/depths. 
 * I imagine that you might want to control which collisions are reported in the simulator, i.e. ignore collisions with the floor and table. 