### PR TITLE
Prepare for release 1.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,8 @@ Changelog for package simulation_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Initial release of the simulation_interfaces package.
 
-Forthcoming
------------
+1.0.0 (2025-04-16)
+------------------
 * Proposal for simulation interfaces (`#1 <https://github.com/ros-simulation/simulation_interfaces/issues/1>`_)
   Following `ros-infrastructure/rep#410 <https://github.com/ros-infrastructure/rep/issues/410>`_, this PR contains a first version of simulation interfaces.
   Co-authored-by: Martin Pecka <peci1@seznam.cz>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,19 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package simulation_interfaces
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Initial release of the simulation_interfaces package.
+
+Forthcoming
+-----------
+* Proposal for simulation interfaces (`#1 <https://github.com/ros-simulation/simulation_interfaces/issues/1>`_)
+  Following `ros-infrastructure/rep#410 <https://github.com/ros-infrastructure/rep/issues/410>`_, this PR contains a first version of simulation interfaces.
+  Co-authored-by: Martin Pecka <peci1@seznam.cz>
+  Co-authored-by: Steve Peters <computersthatmove@gmail.com>
+  Co-authored-by: David V. Lu!! <davidvlu@gmail.com>
+  Co-authored-by: Addisu Z. Taddese <addisu@openrobotics.org>
+  Co-authored-by: Tully Foote <tully.foote@gmail.com>
+  Co-authored-by: Sebastian Castro <4603398+sea-bass@users.noreply.github.com>
+  Co-authored-by: Michał Pełka <michal.pelka@robotec.ai>
+  Co-authored-by: Paweł Liberadzki <pawel.liberadzki@gmail.com>
+* Initial commit
+* Contributors: Adam Dąbrowski, Addisu Z. Taddese

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,19 +1,8 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package simulation_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Initial release of the simulation_interfaces package.
 
 1.0.0 (2025-04-16)
 ------------------
-* Proposal for simulation interfaces (`#1 <https://github.com/ros-simulation/simulation_interfaces/issues/1>`_)
-  Following `ros-infrastructure/rep#410 <https://github.com/ros-infrastructure/rep/issues/410>`_, this PR contains a first version of simulation interfaces.
-  Co-authored-by: Martin Pecka <peci1@seznam.cz>
-  Co-authored-by: Steve Peters <computersthatmove@gmail.com>
-  Co-authored-by: David V. Lu!! <davidvlu@gmail.com>
-  Co-authored-by: Addisu Z. Taddese <addisu@openrobotics.org>
-  Co-authored-by: Tully Foote <tully.foote@gmail.com>
-  Co-authored-by: Sebastian Castro <4603398+sea-bass@users.noreply.github.com>
-  Co-authored-by: Michał Pełka <michal.pelka@robotec.ai>
-  Co-authored-by: Paweł Liberadzki <pawel.liberadzki@gmail.com>
-* Initial commit
+* Initial release of the simulation_interfaces package - a new Standard ROS 2 interfaces for interacting with simulators.
 * Contributors: Adam Dąbrowski, Addisu Z. Taddese

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,5 +4,17 @@ Changelog for package simulation_interfaces
 
 1.0.0 (2025-04-16)
 ------------------
-* Initial release of the simulation_interfaces package - a new Standard ROS 2 interfaces for interacting with simulators.
-* Contributors: Adam Dąbrowski, Addisu Z. Taddese
+Initial release of the simulation_interfaces package - a new Standard ROS 2 interfaces for interacting with simulators.
+
+The standard defines highly useful features such as spawning robots and other objects, moving things around for testing, stepping through simulation and querying the virtual world for ground truth data. It is supportive of automation and scenario-based testing.
+
+* Contributors: Adam Dąbrowski <adam.dabrowski@robotec.ai>, Addisu Z. Taddese <addisu@openrobotics.org>
+
+* Co-authored-by: Martin Pecka <peci1@seznam.cz>
+* Co-authored-by: Steve Peters <computersthatmove@gmail.com>
+* Co-authored-by: David V. Lu!! <davidvlu@gmail.com>
+* Co-authored-by: Addisu Z. Taddese <addisu@openrobotics.org>
+* Co-authored-by: Tully Foote <tully.foote@gmail.com>
+* Co-authored-by: Sebastian Castro <4603398+sea-bass@users.noreply.github.com>
+* Co-authored-by: Michał Pełka <michal.pelka@robotec.ai>
+* Co-authored-by: Paweł Liberadzki <pawel.liberadzki@gmail.com>


### PR DESCRIPTION
Hello, I would like to prepare the release of the 1.0.0 version of the package.

To proceed with the release, we need some adjustments in the repository
The following action points were identified:
 
- [ ] **Required**: the commit to be released should be tagged with a correct version, e.g., `1.0.0`
- [x] Optional: CHANGELOG.rst shall be available in the repository (provided by this PR)

This PR provides an initial CHANGELOG.rst; please let me know if you'd like to adjust it.