### PR TITLE
Fix compatibility issue for jammy humble

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(action_msgs REQUIRED)
 
 set(msg_files
     "msg/Bounds.msg"
@@ -57,7 +58,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${srv_files}
   ${action_files}
-  DEPENDENCIES builtin_interfaces std_msgs geometry_msgs
+  DEPENDENCIES builtin_interfaces std_msgs geometry_msgs action_msgs
   ADD_LINTER_TESTS
 )
 

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>action_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 


### PR DESCRIPTION
Build farm fails for Jammy humble: https://build.ros2.org/job/Hdev__simulation_interfaces__ubuntu_jammy_amd64/lastBuild/consoleFull with:
```
--- stderr: simulation_interfaces
CMake Error at /opt/ros/humble/share/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake:147 (message):
  Unable to generate action interface for 'action/SimulateSteps.action'.  In
  order to generate action interfaces you must add a depend tag for
  'action_msgs' in your package.xml.
Call Stack (most recent call first):
  CMakeLists.txt:56 (rosidl_generate_interfaces)


---
```

This PR adds the missing `action_msgs` dependency.
