### PR TITLE
[Jazzy] Added missing INVALID_POSE error code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(action_msgs REQUIRED)
 
 set(msg_files
     "msg/Bounds.msg"
@@ -66,7 +67,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${srv_files}
   ${action_files}
-  DEPENDENCIES builtin_interfaces std_msgs geometry_msgs
+  DEPENDENCIES builtin_interfaces std_msgs geometry_msgs action_msgs
   ADD_LINTER_TESTS
 )
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>simulation_interfaces</name>
-  <version>1.4.0</version>
+  <version>1.5.1</version>
   <description>A package containing simulation interfaces including messages, services and actions</description>
   <maintainer email="adam.dabrowski@robotec.ai">Adam Dabrowski</maintainer>
   <license>Apache License 2.0</license>

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>simulation_interfaces</name>
-  <version>1.5.0</version>
+  <version>1.4.0</version>
   <description>A package containing simulation interfaces including messages, services and actions</description>
   <maintainer email="adam.dabrowski@robotec.ai">Adam Dabrowski</maintainer>
   <license>Apache License 2.0</license>
@@ -15,6 +15,7 @@
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>action_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/srv/SetEntityState.srv
+++ b/srv/SetEntityState.srv
@@ -9,4 +9,8 @@ EntityState state                       # New state to set immediately. The time
 
 ---
 
+# Additional result.result_code values for this service. Check result.error_message for further details.
+uint8 INVALID_POSE          = 101       # initial_pose is invalid, such as when the quaternion is invalid or position
+                                        # exceeds simulator world bounds.
+
 Result result


### PR DESCRIPTION
simulation interfaces available on ROS 2 Humble has `INVALID_POSE` error code within `SetEnityState` service.
Sadly this error code was missing for Jazzy distro. This PR adds mentioned error code.


Additionally I added action_msgs dependency to unify codebase across distributions  