### PR TITLE
Add optional bounds type field to GetEntityBounds request

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package simulation_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.2.0 (2026-05-01)
+------------------
+* Add optional ``type`` field to ``GetEntityBounds.srv`` request to allow callers to specify the desired bounding box type (`#26 <https://github.com/ros-simulation/simulation_interfaces/issues/26>`_)
+* Add ``TYPE_UNSPECIFIED`` constant to ``Bounds.msg`` to serve as a no-preference sentinel in service requests (`#26 <https://github.com/ros-simulation/simulation_interfaces/issues/26>`_)
+* Contributors: Ayush Ghosh <ayushg@nvidia.com>
+
 2.1.0 (2026-04-07)
 ------------------
 * Rename ``level_resource`` to ``world_resource`` in ``LoadWorld`` and ``WorldResource`` for consistent terminology (`#13 <https://github.com/ros-simulation/simulation_interfaces/issues/13>`_)

--- a/msg/Bounds.msg
+++ b/msg/Bounds.msg
@@ -17,6 +17,7 @@ uint8 TYPE_BOX           = 1      # Axis-aligned bounding box, points field shou
 uint8 TYPE_CONVEX_HULL   = 2      # Points define a convex hull (at least 3 non-collinear points).
 uint8 TYPE_SPHERE        = 3      # A sphere with center and radius. First element of points vector is the center.
                                   # The x field of the second point of the vector is the radius (y and z are ignored).
+uint8 TYPE_UNSPECIFIED   = 255    # Used in service requests to indicate no preferred type; the simulator decides.
 
 
 uint8 type

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>simulation_interfaces</name>
-  <version>2.1.0</version>
+  <version>2.2.0</version>
   <description>A package containing simulation interfaces including messages, services and actions</description>
   <maintainer email="adam.dabrowski@robotec.ai">Adam Dabrowski</maintainer>
   <license>Apache License 2.0</license>

--- a/srv/GetEntityBounds.srv
+++ b/srv/GetEntityBounds.srv
@@ -2,10 +2,10 @@
 # Support for this interface is indicated through the ENTITY_BOUNDS value in GetSimulationFeatures.
 
 string entity                         # Entity identified by its unique name as returned by GetEntities / SpawnEntity.
+uint8 type 255                        # Requested bounding box type. Use Bounds.TYPE_* constants.
+                                      # Defaults to TYPE_UNSPECIFIED (255), meaning no preference: the simulator chooses,
 
 ---
 
 Result result
 Bounds bounds                         # Entity bounds. Only valid if result.result_code is OK.
-                                      # Bounds with TYPE_BOX should be returned, unless there is a configuration
-                                      # parameter for the simulator to control the type and it is set otherwise.


### PR DESCRIPTION
Adds an optional type field to GetEntityBounds.srv so callers can specify their preferred bounding box representation (box, sphere, convex hull). If unset, it defaults to TYPE_UNSPECIFIED (255), preserving existing behavior where the simulator picks the type.                                       

Also adds the TYPE_UNSPECIFIED constant to Bounds.msg as a clean sentinel value for use in requests, distinct from the existing response types.

Closes #26.  